### PR TITLE
Fixes only one option of final argument being read

### DIFF
--- a/getopt/getopt.lua
+++ b/getopt/getopt.lua
@@ -8,21 +8,20 @@
 function getopt(args, options)
   checkArg(1, args, "table")
   checkArg(2, options, "string")
+
   local current = nil
   local pos = 1
   return function()
-    if #args <= 0 then
-      return nil -- No arguments left to process
-    end
-    if not current or #current < pos then
-      if string.find(args[1], "^%-%w") then
-        current = string.sub(args[1], 2, #args[1])
+    if not current or pos > #current then
+      if #args > 0 and string.find(args[1], "^%-%w") then
+        current = table.remove(args, 1):sub(2)
         pos = 1
-        table.remove(args, 1)
       else
-        return nil -- No options left to process, the rest is up to the program
+        -- No options left to process, the rest is up to the program
+        return nil
       end
     end
+
     local char = current:sub(pos, pos)
     pos = pos +1
     if char == '-' then


### PR DESCRIPTION
There's an issue where only the first option in a bundled argument will be read if it's the final argument--invoking a command as `foo -bar` causes getopt to only return `b`. This is because the first check in the function is `#args > 0`. It ignores the case where `current` still has remaining flags.

You should be able to see the issue with this (untested) script:

``` lua
package.loaded.getopt = nil -- so you don't have to reboot between changes to the library
local getopt = require("getopt")
for opt, arg in getopt({...}, "bar") do
  print(opt, arg)
end

-- foo -bar
-- expected:
--  b
--  a
--  r
-- actual:
--  b
```

The problem is usually masked because most commands take a non-flag argument. This patch modifies the logic at the top to check for remaining flags in `current`.
